### PR TITLE
Disocvery should use async socket

### DIFF
--- a/Onkyo/onkyo-receiver/src/disco.lua
+++ b/Onkyo/onkyo-receiver/src/disco.lua
@@ -12,7 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-local socket = require('socket')
+local socket = require('cosock.socket')
 local log = require('log')
 local config = require('config')
 


### PR DESCRIPTION
Updated require statement to refer to `cosock.socket` instead of `socket`